### PR TITLE
Several OSLC Test Suite Bug Fixes

### DIFF
--- a/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/ChangeRequestXmlTests.java
+++ b/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/ChangeRequestXmlTests.java
@@ -114,7 +114,8 @@ public class ChangeRequestXmlTests extends TestsBase {
 	
 		ArrayList<String> results = new ArrayList<String>();
 		for (String queryBase : capabilityURLsUsingXML) {
-			HttpResponse resp = OSLCUtils.getResponseFromUrl(setupBaseUrl, queryBase + query, basicCreds, 
+			String queryUrl = OSLCUtils.addQueryStringToURL(queryBase, query);
+			HttpResponse resp = OSLCUtils.getResponseFromUrl(setupBaseUrl, queryUrl, basicCreds, 
 					OSLCConstants.CT_XML, headers);
 			String respBody = EntityUtils.toString(resp.getEntity());
 			EntityUtils.consume(resp.getEntity());

--- a/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/ServiceProviderRdfXmlTests.java
+++ b/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/ServiceProviderRdfXmlTests.java
@@ -172,8 +172,9 @@ public class ServiceProviderRdfXmlTests extends TestsBase {
 		HttpResponse baseResp = OSLCUtils.getResponseFromUrl(setupBaseUrl, currentUrl, basicCreds,
 				OSLCConstants.CT_XML, headers);
 		String baseRespValue = EntityUtils.toString(baseResp.getEntity());
-		
-		HttpResponse parameterResp = OSLCUtils.getResponseFromUrl(setupBaseUrl, currentUrl + "?oslc_cm:query", basicCreds,
+
+		String modifiedUrl = OSLCUtils.addParameterToURL(currentUrl, "oslc.where", "dcterms:identifier=\"1\"");
+		HttpResponse parameterResp = OSLCUtils.getResponseFromUrl(setupBaseUrl, modifiedUrl, basicCreds,
 				OSLCConstants.CT_XML, headers);
 		String parameterRespValue = EntityUtils.toString(parameterResp.getEntity());
 		

--- a/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/ServiceProviderXmlTests.java
+++ b/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/ServiceProviderXmlTests.java
@@ -138,7 +138,8 @@ public class ServiceProviderXmlTests extends TestsBase {
 		String baseRespValue = EntityUtils.toString(baseResp.getEntity());
 		EntityUtils.consume(baseResp.getEntity());
 		
-		HttpResponse parameterResp = OSLCUtils.getResponseFromUrl(setupBaseUrl, currentUrl + "?oslc_cm:query", basicCreds,
+		String modifiedUrl = OSLCUtils.addParameterToURL(currentUrl, "oslc.where", "dcterms:identifier=\"1\"");
+		HttpResponse parameterResp = OSLCUtils.getResponseFromUrl(setupBaseUrl, modifiedUrl, basicCreds,
 				OSLCConstants.CT_XML, headers);
 		String parameterRespValue = EntityUtils.toString(parameterResp.getEntity());
 		EntityUtils.consume(parameterResp.getEntity());

--- a/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/SimplifiedQueryRdfXmlTests.java
+++ b/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/oslcv2tests/SimplifiedQueryRdfXmlTests.java
@@ -85,8 +85,9 @@ public class SimplifiedQueryRdfXmlTests extends SimplifiedQueryBaseTests {
 
 	protected void validateNonEmptyResponse(String query)
 			throws IOException {
+		String queryUrl = OSLCUtils.addQueryStringToURL(currentUrl, query);
 		HttpResponse response = OSLCUtils.getResponseFromUrl(setupBaseUrl,
-				currentUrl + query, basicCreds, OSLCConstants.CT_RDF, headers);
+				queryUrl, basicCreds, OSLCConstants.CT_RDF, headers);
 		assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
 
 		Model queryModel = ModelFactory.createDefaultModel();
@@ -94,7 +95,7 @@ public class SimplifiedQueryRdfXmlTests extends SimplifiedQueryBaseTests {
 				OSLCUtils.absoluteUrlFromRelative(setupBaseUrl, currentUrl),
 				OSLCConstants.JENA_RDF_XML);
 		EntityUtils.consume(response.getEntity());
-		Resource responseInfoRes = (Resource) queryModel.getResource(currentUrl + query);
+		Resource responseInfoRes = (Resource) queryModel.getResource(queryUrl);
 		assumeNotNull("Expended ResponseInfo/@rdf:about to equal request URL", responseInfoRes);
 		Resource resultsRes = (Resource) queryModel.getResource(currentUrl);
 		assumeNotNull(resultsRes);

--- a/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/util/OSLCUtils.java
+++ b/org.eclipse.lyo.testsuite.server/src/main/java/org/eclipse/lyo/testsuite/server/util/OSLCUtils.java
@@ -19,10 +19,14 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
+import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.net.URLEncoder;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Scanner;
 
 import javax.net.ssl.SSLContext;
@@ -52,6 +56,7 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.protocol.BasicHttpContext;
 import org.apache.http.util.EntityUtils;
+import org.junit.Assert;
 import org.w3c.dom.Document;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -299,5 +304,92 @@ public class OSLCUtils {
 		//Get the response and return it
 		HttpResponse response = httpclient.execute(httppost);
 		EntityUtils.consume(response.getEntity());
+	}
+
+	/**
+	 * Adds a query string to the end of a URL, handling the case where the URL
+	 * already has query parameters.
+	 * 
+	 * @param url
+	 *            the URL to modify. It may or may not already have query
+	 *            parameters.
+	 * @param queryString
+	 *            the query string, starting with a '?'. For instance,
+	 *            "?oslc.properties=dcterms%3Aidentifier". Parameter values must
+	 *            already be encoded.
+	 * @return the new URL
+	 */
+	public static String addQueryStringToURL(String url, String queryString) {
+		Assert.assertTrue("queryString must begin with a '?'",
+				queryString.startsWith("?"));
+		if (url.indexOf('?') == -1) {
+			return url + queryString;
+		}
+
+		return url + '&' + queryString.substring(1);
+	}
+
+	/**
+	 * Adds query parameter values to a URL.
+	 * 
+	 * @param url
+	 *            the URL to modify
+	 * @param params
+	 *            a map of query parameters as name/value pairs
+	 * @return the new URL
+	 * @throws UnsupportedEncodingException
+	 *             on errors encoding the values
+	 */
+	public static String addParametersToURL(String url,
+			Map<String, String> queryParameters)
+			throws UnsupportedEncodingException {
+		StringBuffer updatedUrl = new StringBuffer(url);
+		if (url.indexOf('?') == -1) {
+			updatedUrl.append('?');
+		} else {
+			updatedUrl.append('&');
+		}
+
+		boolean first = true;
+		for (Entry<String, String> next : queryParameters.entrySet()) {
+			if (!first) {
+				updatedUrl.append("&");
+			}
+			updatedUrl.append(URLEncoder.encode(next.getKey(), "UTF-8"));
+			updatedUrl.append("=");
+			updatedUrl.append(URLEncoder.encode(next.getValue(), "UTF-8"));
+			first = false;
+		}
+
+		return updatedUrl.toString();
+	}
+
+	/**
+	 * Adds a single query parameter to a URL.
+	 * 
+	 * @param url
+	 *            the URL to modify
+	 * @param name
+	 *            the parameter name
+	 * @param value
+	 *            the parameter value
+	 * @return the new URL
+	 * @throws UnsupportedEncodingException
+	 *             on errors encoding the values
+	 */
+	public static String addParameterToURL(String url, String name, String value)
+			throws UnsupportedEncodingException {
+		StringBuffer updatedUrl = new StringBuffer(url);
+		if (url.indexOf('?') == -1) {
+			updatedUrl.append('?');
+		} else {
+			updatedUrl.append('&');
+		}
+
+		updatedUrl.append(URLEncoder.encode(name, "UTF-8"));
+		updatedUrl.append("=");
+		updatedUrl.append(URLEncoder.encode(value, "UTF-8"));
+		
+		return updatedUrl.toString();
 	}
 }


### PR DESCRIPTION
Bug 363219 - Properly encode query parameter values in test suites 

Not all query parameters in the simplified query tests were properly encoded, and they often contained reserved characters like ':'

Bug 363223 - Test suite does not properly set base URI when reading RDF/XML using Jena

Bug 363344 - Test suite does not handle service URIs with query
