### PR TITLE
Bug 527089 - Update TRS API, RIO and Sample for OSLC4J 2.3.0

### DIFF
--- a/org.eclipse.lyo.testsuite.trs/pom.xml
+++ b/org.eclipse.lyo.testsuite.trs/pom.xml
@@ -19,13 +19,20 @@
     xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.eclipse.lyo.testsuite</groupId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <name>TRS Implementation Assessment Test</name>
     <artifactId>testsuite-trs</artifactId>
     <description>Toolkit to assist with TRS implementation testing.</description>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<version-jvm>1.8</version-jvm>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<version-jetty>9.4.6.v20170531</version-jetty>
+		<version.lyo.core>2.2.0</version.lyo.core>
+		<version.lyo.server>2.2.0</version.lyo.server>
     </properties>
 
     <repositories>
@@ -33,6 +40,19 @@
             <id>oauth</id>
             <url>http://oauth.googlecode.com/svn/code/maven</url>
         </repository>
+		<repository>
+			<id>lyo-releases</id>
+			<name>lyo-releases repository</name>
+			<url>https://repo.eclipse.org/content/repositories/lyo-releases/</url>
+		</repository>
+		<repository>
+			<id>lyo-snapshots</id>
+			<name>Eclipse Lyo Snapshots</name>
+			<url>https://repo.eclipse.org/content/repositories/lyo-snapshots/</url>
+			<releases>
+				<enabled>false</enabled>
+			</releases>
+		</repository>
     </repositories>
 
     <dependencies>
@@ -50,12 +70,12 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.1.2</version>
+            <version>4.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo</groupId>
             <artifactId>oslc-trs</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>2.2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.apache.jena</groupId>
@@ -65,22 +85,22 @@
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-core</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>${version.lyo.core}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-wink</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>${version.lyo.core}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-json4j-provider</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>${version.lyo.core}</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.lyo.oslc4j.core</groupId>
             <artifactId>oslc4j-jena-provider</artifactId>
-            <version>3.0.0-SNAPSHOT</version>
+            <version>${version.lyo.core}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.geronimo.specs</groupId>
@@ -104,17 +124,6 @@
         </resources>
         <plugins>
 
-            <!-- Compiler Plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>2.3.2</version>
-                <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
-                </configuration>
-            </plugin>
-
             <!-- Source Jar Plugin -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -133,6 +142,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalparam>-Xdoclint:none</additionalparam>
+                </configuration>
+                
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Set pom.xml to 2.3.0-SNAPSHOT

 Conflicts:
	org.eclipse.lyo.testsuite.trs/pom.xml